### PR TITLE
[OBS-80] 자동 release 올리기 추가

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      # Install dependencies
+      - name: Install dependencies
+        run: pnpm install
+
+      # Build project
+      - name: Build project
+        run: pnpm build
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            manifest.json
+            main.js
+          generate_release_notes: true


### PR DESCRIPTION
## 요약

- release 노트를 자동으로 생성해주는 수동 workflow 추가

## PR 체크리스트

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 코드의 포맷팅이 전체적으로 올바르게 되어 있습니다.
- [ ] Lint 오류 등이 발생하지 않습니다.

## 스크린샷 (선택사항)

## 비고

- 대신 자동으로 생성된 버전 태그를 쓰므로, manifest.json과 호환이 안되는 문제 발생